### PR TITLE
Enable builds for ARM.

### DIFF
--- a/flathub.json
+++ b/flathub.json
@@ -1,3 +1,3 @@
 {
-    "skip-arches": ["arm", "aarch64"]
+    "only-arches": ["x86_64", "arm", "aarch64"]
 }


### PR DESCRIPTION
ARM architectures are now supported as of v1.0.0:
https://github.com/00-Evan/shattered-pixel-dungeon/issues/385#issuecomment-900428904

flathub.json is changed to allow only supported architectures, so that unsupported architectures are excluded by default.